### PR TITLE
venue map linking with content pages

### DIFF
--- a/content/schedule/b2b.md
+++ b/content/schedule/b2b.md
@@ -2,6 +2,7 @@
 title: "Business-to-business"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:51:24+06:00
+map_select_id: [2]
 draft: false
 layout: "single"
 ---

--- a/content/schedule/bof.md
+++ b/content/schedule/bof.md
@@ -2,6 +2,7 @@
 title: "Birds-of-a-Feather"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:55:24+06:00
+map_select_id: [1]
 draft: false
 layout: "single"
 ---

--- a/content/schedule/city-tour.md
+++ b/content/schedule/city-tour.md
@@ -3,6 +3,7 @@ title: "Free city tour"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-03-01T12:55:24+06:00
 image: "images/city-tour.png"
+map_select_id: [8]
 draft: false
 layout: "single"
 ---

--- a/content/schedule/community-sprint.md
+++ b/content/schedule/community-sprint.md
@@ -2,6 +2,7 @@
 title: "Community Sprint"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:57:24+06:00
+map_select_id: [1]
 draft: false
 layout: "single"
 ---

--- a/content/schedule/excursion.md
+++ b/content/schedule/excursion.md
@@ -2,6 +2,7 @@
 title: "Excursion"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2020-03-14T15:40:24+06:00
+map_select_id: [1]
 draft: false
 layout: "single"
 ---

--- a/content/schedule/geochicas-take-tartu.md
+++ b/content/schedule/geochicas-take-tartu.md
@@ -2,6 +2,7 @@
 title: "GeoChicas Take Tartu"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:52:24+06:00
+map_select_id: [9]
 image: "images/geochicas_banner.png"
 draft: false
 layout: "single"

--- a/content/schedule/ice-breaker.md
+++ b/content/schedule/ice-breaker.md
@@ -2,6 +2,7 @@
 title: "Ice-Breaker"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:53:24+06:00
+map_select_id: [10]
 image: "images/aparaaditehas.jpg"
 draft: false
 layout: "single"

--- a/content/schedule/ogc-euidays.md
+++ b/content/schedule/ogc-euidays.md
@@ -2,6 +2,7 @@
 title: "OGC Innovation Days Europe"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-03-01T13:53:24+02:00
+map_select_id: [3]
 image: "images/iDays-EU-2024.jpg"
 draft: false
 layout: "single"
@@ -19,7 +20,7 @@ Date & time: July 1, 2024 9:00 am --- July 2, 2024 5:30 pm
 
 ##### Location
 
-Riia 23b (Omicum building) 
+Riia 23b (Omicum building)
 
 Tartu, Estonia
 

--- a/content/schedule/social-bytes.md
+++ b/content/schedule/social-bytes.md
@@ -2,6 +2,7 @@
 title: "Social Bytes"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2024-02-29T16:54:24+06:00
+map_select_id: [7]
 image: "images/lodjakoda.jpg"
 draft: false
 layout: "single"
@@ -36,7 +37,7 @@ comfortably.
 >}}
 
 We are also honoured to introduce the performer of the night who is an Estonian folk-rock band called **{{< extlink href="https://www.youtube.com/@Zetod" title="Zetod" >}}**!    
-Zetod is a musical phenomenon born in Värska in 2003 as a youth band under the guidance of Kristjan Priks, a graduate of the Viljandi Academy of Culture's folk music major. The idea of getting young Seto boys to make pop-rock in the key of their own culture was exciting at the time and has brought this group to the top today, which has brought many awards and recognition. The ensemble, which has released seven studio albums, celebrated its 20th anniversary in 2023. 
+Zetod is a musical phenomenon born in Värska in 2003 as a youth band under the guidance of Kristjan Priks, a graduate of the Viljandi Academy of Culture's folk music major. The idea of getting young Seto boys to make pop-rock in the key of their own culture was exciting at the time and has brought this group to the top today, which has brought many awards and recognition. The ensemble, which has released seven studio albums, celebrated its 20th anniversary in 2023.
 Zetod composition:
 - Jalmar Vabarna
 - Matis Leima

--- a/content/schedule/talks.md
+++ b/content/schedule/talks.md
@@ -3,6 +3,7 @@ title : "Talks"
 page_header_bg : "images/background/page-title-bg.jpg"
 date: 2024-04-02T11:10:24+03:00
 description : "FOSS4G Europe 2024 presentations schedule for 3-5 July 2024."
+map_select_id: [1, 3]
 draft : false
 pretalx: "foss4g-europe-2024"
 type: "agenda"

--- a/content/schedule/workshops.md
+++ b/content/schedule/workshops.md
@@ -3,6 +3,7 @@ title : "Workshops"
 page_header_bg : "images/background/page-title-bg.jpg"
 date: 2020-11-01T12:21:24+02:00
 description : "FOSS4G Europe 2024 workshops schedule for 1-2 July 2024."
+map_select_id: [1]
 draft : false
 pretalx: "foss4g-europe-2024-workshops"
 type: "agenda"

--- a/content/venue/about-venue.md
+++ b/content/venue/about-venue.md
@@ -1,8 +1,8 @@
 ---
 title: "About Venue"
 page_header_bg: "images/background/page-title-bg.jpg"
-date: 2020-03-14T15:40:24+06:00
-description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Maiores, velit."
+date: 2024-03-14T15:40:24+06:00
+map_select_id: [1,2,3]
 draft: false
 layout: "single"
 ---

--- a/content/venue/getting-to-tartu.md
+++ b/content/venue/getting-to-tartu.md
@@ -2,7 +2,7 @@
 title: "Getting to Tartu"
 page_header_bg: "images/background/page-title-bg.jpg"
 date: 2020-03-14T15:40:24+06:00
-description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Maiores, velit."
+map_select_id: [4,5,6]
 draft: false
 layout: "single"
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -439,6 +439,7 @@ icon = "train"
 markerColor = "#f06a36"
 
 [[params.map.layer]]
+id = 1
 name = "Conference Venues"
 title = "Department of Geography"
 address = "Vanemuise 46"
@@ -452,6 +453,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 2
 name = "Conference Venues"
 title = "Mart Reiniku Building"
 address = "Vanemuise 48"
@@ -464,6 +466,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 3
 name = "Conference Venues"
 title = "Omicum Building"
 address = "Riia 23"
@@ -475,6 +478,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 4
 name = "Arrival Points"
 title = "Train station"
 address = "Vaksali 6"
@@ -483,6 +487,7 @@ icon = "train"
 url = ""
 
 [[params.map.layer]]
+id = 5
 name = "Arrival Points"
 title = "Airport"
 address = "Lennu 44, Reola"
@@ -491,6 +496,7 @@ icon = "airport"
 url = ""
 
 [[params.map.layer]]
+id = 6
 name = "Arrival Points"
 title = "Bus station"
 address = "Turu 2"
@@ -499,6 +505,7 @@ icon = "bus"
 url = ""
 
 [[params.map.layer]]
+id = 7
 name = "Social Events"
 title = "Emajõe Lodjakoda"
 address = "Ujula 98"
@@ -511,6 +518,7 @@ events = [
 
 [[params.map.layer]]
 name = "Social Events"
+id = 8
 title = "City Hall square"
 address = "Raekoja plats 1a"
 location = [58.380139, 26.722391]
@@ -520,6 +528,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 9
 name = "Social Events"
 title = "Kultuuriklubi Salong"
 address = "Vanemuise 19"
@@ -531,6 +540,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 10
 name = "Social Events"
 title = "Kolm Tilli"
 address = "Kastani 42"
@@ -542,6 +552,7 @@ events = [
 ]
 
 [[params.map.layer]]
+id = 11
 name = "Pub Crawl"
 title = "Mülä"
 img = "images/map-icons/myla.png"
@@ -550,6 +561,7 @@ location = [58.386078, 26.721008]
 icon = "pubcrawl"
 
 [[params.map.layer]]
+id = 12
 name = "Pub Crawl"
 title = "Möku"
 img = "images/map-icons/moku.png"
@@ -558,6 +570,7 @@ location = [58.383479, 26.721896]
 icon = "pubcrawl"
 
 [[params.map.layer]]
+id = 13
 name = "Pub Crawl"
 title = "Vein ja Vine"
 img = "images/map-icons/veinjavine.png"
@@ -566,6 +579,7 @@ location = [58.38115, 26.7217]
 icon = "pubcrawl"
 
 [[params.map.layer]]
+id = 14
 name = "Pub Crawl"
 title = "Illegaard"
 img = "images/map-icons/illegaard.png"
@@ -574,6 +588,7 @@ location = [58.379488, 26.722369]
 icon = "pubcrawl"
 
 [[params.map.layer]]
+id = 15
 name = "Pub Crawl"
 title = "Pühaste kelder"
 img = "images/map-icons/pyhaste.png"
@@ -582,6 +597,7 @@ location = [58.3813, 26.7219]
 icon = "pubcrawl"
 
 [[params.map.layer]]
+id = 16
 name = "Pub Crawl"
 title = "Barlova"
 img = "images/map-icons/barlova.jpg"

--- a/themes/eventre-hugo/layouts/partials/footer.html
+++ b/themes/eventre-hugo/layouts/partials/footer.html
@@ -39,13 +39,14 @@
 <!--================================
 =            Google Map            =
 =================================-->
+
 {{ if site.Params.map.enable }}
 {{ with site.Params.map }}
 <section class="map" >
 	<!-- Google Map -->
 
   <div id="map" width="100%" style="height:550px">
-  {{ partial "map.html" }}
+  {{ partial "map.html" $ }}
   </div>
 
 	<div class="address-block" style="position:absolute;z-index:1000">

--- a/themes/eventre-hugo/layouts/partials/map.html
+++ b/themes/eventre-hugo/layouts/partials/map.html
@@ -22,6 +22,8 @@
   const icons = {};
   const layers = {};
   const layernames = {};
+  const selectId = {{ .Params.map_select_id }} || [];
+  const bounds = [];
 
   {{ range site.Params.map.icon }}
     if ({{ .type }} == "fa") {
@@ -64,9 +66,17 @@
     popUpContent != "" ? {{ site.Params.map.popupTemplatePrefix }} + popUpContent + {{ site.Params.map.popupTemplateSuffix }} : "";
     var marker = L.marker(
       {{ .location }}, {
-        icon:icons[{{ .icon }}]
+        icon:L.AwesomeMarkers.icon({
+          prefix: "fa",
+          icon: icons[{{ .icon }}].options.icon,
+          markerColor: selectId.includes("{{ .id }}") ? icons[{{ .icon }}].options.markerColor || "black" : "gray"
+        })
       }
     ).addTo(layer);
+
+    if (selectId.includes("{{ .id }}")) {
+      bounds.push({{ .location }})
+    }
 
     var titleBits = {{ site.Params.map.popupTitleTemplate }};
     titleBits += {{ .img }} == null ? "": "<div align=\"center\"><img src=\"{src}\" style=\"border-radius:50%;height:96px;border:4px solid black\"></div>";
@@ -89,6 +99,10 @@
     marker.bindPopup(popUpContent);
   {{ end }}
 
+
+  if (bounds.length > 0) {
+    venueMap.flyToBounds(bounds, {maxZoom:15});
+  }
   for (var k in layers) {
     delete Object.assign(layers, {[layernames[k]+" "+k]: layers[k] })[k];
   }


### PR DESCRIPTION
on any of the content page headers add

`map_select_id = [some-number]`
or to "select many" from the footer map
`map_select_id = [a, list, of, numbers]`

make sure in the `hugo.toml` file to have `id` assigned for those `[[params.map.layer]]` objects, e.g.

```
[[params.map.layer]]
id = 10
name = "Social Events"
title = "Kolm Tilli"
address = "Kastani 42"
img="images/map-icons/kolmtilli.jpg"
location = [58.3703996, 26.7165455]
icon = "social"
events = [
  {name="Ice-Breaker", date="3 July", url="./schedule/ice-breaker/"},
]
url = "https://www.facebook.com/kolmtilli/"
```

and in the content/schedule/ice-breaker.md we have

```
---
title: "Ice-Breaker"
page_header_bg: "images/background/page-title-bg.jpg"
date: 2024-02-29T16:53:24+06:00
map_select_id: [10]
image: "images/aparaaditehas.jpg"
draft: false
layout: "single"
---
```
so when looking at the footer map from the Schedule -> Ice-Breaker page we get:

![image](https://github.com/2024-foss4g-europe/2024-foss4g-europe.github.io/assets/8924478/58062a7e-6d1c-4642-bef5-a3aa663da1f2)


