### PR TITLE
fix menu clicks on main and building error locally

### DIFF
--- a/themes/eventre-hugo/layouts/partials/head.html
+++ b/themes/eventre-hugo/layouts/partials/head.html
@@ -46,8 +46,7 @@ AUTHOR WEBSITE: https://themefisher.com
   <meta property="og:image" content="{{ . | absURL }}" />
   {{ end }}
   {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/google_analytics.html" . }}
-  {{ template "_internal/google_analytics_async.html" . }}
+
   {{ if .Params.pretalx }}
   <script type="text/javascript" src="https://talks.osgeo.org/{{ .Params.pretalx }}/schedule/widget/v2.en.js"></script>
   {{ end }}

--- a/themes/eventre-hugo/layouts/partials/header.html
+++ b/themes/eventre-hugo/layouts/partials/header.html
@@ -20,7 +20,7 @@
         {{ range site.Menus.main }}
         {{ if .HasChildren }}
         <li class="nav-item dropdown dropdown-slide">
-          <a class="nav-link" href="#" data-toggle="dropdown">{{.Name}}
+          <a class="nav-link" href="{{if .Pre}}{{site.BaseURL | absLangURL}}{{.Pre}}{{ .URL }}{{else}}{{.URL | absLangURL}}{{end}}" data-toggle="">{{.Name}}
             <span>/</span>
           </a>
           <!-- Dropdown list -->


### PR DESCRIPTION
- Fixes click on main menu elements, because those were not opening on click, instead only the dropdown was showing.
- Removed two lines from template pages because it was referring to a google analytics file that we had deleted and local build was not successful.